### PR TITLE
Added support for XML header nodes.

### DIFF
--- a/plump-sexp.lisp
+++ b/plump-sexp.lisp
@@ -79,7 +79,7 @@ Alternatively a pathname, stream or string may be passed as well, which will be 
   (:documentation "Serialize the given node into a SEXP form.")
   (:method ((node xml-header))
     (list
-     (cons :!HEADER
+     (list* :!HEADER
            (when (< 0 (hash-table-count (attributes node)))
              (loop for key being the hash-keys of (attributes node)
                    for val being the hash-values of (attributes node)

--- a/plump-sexp.lisp
+++ b/plump-sexp.lisp
@@ -83,7 +83,7 @@ Alternatively a pathname, stream or string may be passed as well, which will be 
            (when (< 0 (hash-table-count (attributes node)))
              (loop for key being the hash-keys of (attributes node)
                    for val being the hash-values of (attributes node)
-                   nconc (list (string->name key) val))))))
+                   collect (string->name key) collect val)))))
   (:method ((node comment))
     (list :!COMMENT (text node)))
   (:method ((node doctype))


### PR DESCRIPTION
Was trying to read and write XML files with header nodes.

There is one design question that may require that this PR be changed. In serialize, I made it so that header nodes are formatted just like elements in that they are a list within a list except that the first element of the inner list is ```:!HEADER```. Another reasonable way to format it would be to not use a nested list and/or change the first element of the inner list.