### PR TITLE
Update plump-sexp.lisp

### DIFF
--- a/plump-sexp.lisp
+++ b/plump-sexp.lisp
@@ -54,6 +54,7 @@
                 (loop for child in blocks
                       do (transform-sexp child node)))))))
      root)
+    (plump:element (plump:append-child root input))
     (T (unless root (setf root (make-root)))
      (make-text-node root (princ-to-string input)))))
 


### PR DESCRIPTION
allow plump:elements to be used in mix of sexp in `transform-sexp`.